### PR TITLE
Sync drivers

### DIFF
--- a/prefect_sqlalchemy/__init__.py
+++ b/prefect_sqlalchemy/__init__.py
@@ -1,4 +1,4 @@
 from . import _version
-from .credentials import DatabaseCredentials, AsyncDriver  # noqa
+from .credentials import DatabaseCredentials, AsyncDriver, SyncDriver  # noqa
 
 __version__ = _version.get_versions()["version"]

--- a/prefect_sqlalchemy/credentials.py
+++ b/prefect_sqlalchemy/credentials.py
@@ -23,6 +23,18 @@ class AsyncDriver(Enum):
     MYSQL_AIOMYSQL = "mysql+aiomysql"
 
 
+class SyncDriver(Enum):
+    """
+    Known dialects with their corresponding sync drivers.
+    """
+
+    POSTGRESQL_PSYCOPG2 = "postgresql+psycopg2"
+    POSTGRESQL_PG8000 = "postgresql+pg8000"
+    POSTGRESQL_PSYCOPG2CFFI = "postgresql+psycopg2cffi"
+    POSTGRESQL_PYPOSTGRESQL = "postgresql+pypostgresql"
+    POSTGRESQL_PYGRESQL = "postgresql+pygresql"
+
+
 @dataclass
 class DatabaseCredentials:
     """
@@ -85,12 +97,12 @@ class DatabaseCredentials:
         Examples:
             ```python
             from prefect import flow
-            from prefect_sqlalchemy import DatabaseCredentials, AsyncDrivers
+            from prefect_sqlalchemy import DatabaseCredentials, AsyncDriver
 
             @flow
             def sqlalchemy_credentials_flow():
                 sqlalchemy_credentials = DatabaseCredentials(
-                    drivername=AsyncDrivers.POSTGRESQL_ASYNCPG,
+                    driver=AsyncDriver.POSTGRESQL_PSYCOPG,
                     username="prefect",
                     password="prefect_password",
                     database="postgres"

--- a/prefect_sqlalchemy/credentials.py
+++ b/prefect_sqlalchemy/credentials.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import create_async_engine
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
     from sqlalchemy.ext.asyncio.engine import AsyncConnection
 
 from prefect.logging import get_run_logger
@@ -123,15 +124,16 @@ class DatabaseCredentials:
             f"using the connection string: {url_repr}."
         )
 
-    def get_connection(self) -> "AsyncConnection":
+    def get_connection(self) -> Union["Connection", "AsyncConnection"]:
         """
         Returns an authenticated connection that can be
-        used to query from Snowflake databases.
+        used to query from databases.
 
         Returns:
-            The authenticated SQLAlchemy AsyncConnection.
+            The authenticated SQLAlchemy Connection / AsyncConnection.
 
         Examples:
+            Create an asynchronous connection.
             ```python
             from prefect import flow
             from prefect_sqlalchemy import DatabaseCredentials, AsyncDriver

--- a/prefect_sqlalchemy/database.py
+++ b/prefect_sqlalchemy/database.py
@@ -19,9 +19,14 @@ async def _execute(
     """
     Executes a SQL query.
     """
-    async with sqlalchemy_credentials.get_connection() as connection:
-        result = await connection.execute(text(query), params)
-        await connection.commit()
+    if sqlalchemy_credentials.is_async:
+        async with sqlalchemy_credentials.get_connection() as connection:
+            result = await connection.execute(text(query), params)
+            await connection.commit()
+    else:
+        with sqlalchemy_credentials.get_connection() as connection:
+            result = connection.execute(text(query), params)
+            # commit is not available
     return result
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,5 @@ mock; python_version < '3.8'
 mkdocs-gen-files
 interrogate
 coverage
+psycopg2
+asyncpg

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,7 +1,8 @@
 import pytest
 from prefect import flow
-from sqlalchemy.engine import Connection
-from sqlalchemy.ext.asyncio.engine import AsyncConnection
+from sqlalchemy.engine import Engine, create_mock_engine
+from sqlalchemy.engine.mock import MockConnection
+from sqlalchemy.ext.asyncio.engine import AsyncConnection, AsyncEngine
 
 from prefect_sqlalchemy.credentials import AsyncDriver, DatabaseCredentials, SyncDriver
 
@@ -9,7 +10,7 @@ from prefect_sqlalchemy.credentials import AsyncDriver, DatabaseCredentials, Syn
 @pytest.mark.parametrize(
     "driver", [AsyncDriver.POSTGRESQL_ASYNCPG, "postgresql+asyncpg"]
 )
-def test_sqlalchemy_credentials_get_connection_async(driver):
+def test_sqlalchemy_credentials_get_connection_async(monkeypatch, driver):
     @flow
     def test_flow():
         sqlalchemy_credentials = DatabaseCredentials(
@@ -17,9 +18,10 @@ def test_sqlalchemy_credentials_get_connection_async(driver):
         )
         expected = "postgresql+asyncpg://user:***@localhost:5432/database"
         assert sqlalchemy_credentials.engine.url.render_as_string() == expected
+        assert sqlalchemy_credentials.is_async is True
+        assert isinstance(sqlalchemy_credentials.engine, AsyncEngine)
         connection = sqlalchemy_credentials.get_connection()
         assert isinstance(connection, AsyncConnection)
-        assert sqlalchemy_credentials.is_async is True
 
     test_flow().result()
 
@@ -35,8 +37,15 @@ def test_sqlalchemy_credentials_get_connection_sync(driver):
         )
         expected = "postgresql+psycopg2://user:***@localhost:5432/database"
         assert sqlalchemy_credentials.engine.url.render_as_string() == expected
-        connection = sqlalchemy_credentials.get_connection()
-        assert isinstance(connection, Connection)
         assert sqlalchemy_credentials.is_async is False
+        # first check if it's the proper engine
+        assert isinstance(sqlalchemy_credentials.engine, Engine)
+        # can't use monkeypatch or else affects Orion as well
+        # so manually replace it with a mock engine
+        sqlalchemy_credentials.engine = create_mock_engine(
+            sqlalchemy_credentials.engine.url, ""
+        )
+        connection = sqlalchemy_credentials.get_connection()
+        assert isinstance(connection, MockConnection)
 
     test_flow().result()

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,15 +1,42 @@
 import pytest
+from prefect import flow
+from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio.engine import AsyncConnection
 
-from prefect_sqlalchemy.credentials import AsyncDriver, DatabaseCredentials
+from prefect_sqlalchemy.credentials import AsyncDriver, DatabaseCredentials, SyncDriver
 
 
 @pytest.mark.parametrize(
     "driver", [AsyncDriver.POSTGRESQL_ASYNCPG, "postgresql+asyncpg"]
 )
-def test_sqlalchemy_credentials_get_connection(driver):
-    sqlalchemy_credentials = DatabaseCredentials(driver, "user", "password", "database")
-    expected = "postgresql+asyncpg://user:***@localhost:5432/database"
-    assert sqlalchemy_credentials.engine.url.render_as_string() == expected
-    connection = sqlalchemy_credentials.get_connection()
-    assert isinstance(connection, AsyncConnection)
+def test_sqlalchemy_credentials_get_connection_async(driver):
+    @flow
+    def test_flow():
+        sqlalchemy_credentials = DatabaseCredentials(
+            driver, "user", "password", "database"
+        )
+        expected = "postgresql+asyncpg://user:***@localhost:5432/database"
+        assert sqlalchemy_credentials.engine.url.render_as_string() == expected
+        connection = sqlalchemy_credentials.get_connection()
+        assert isinstance(connection, AsyncConnection)
+        assert sqlalchemy_credentials.is_async is True
+
+    test_flow().result()
+
+
+@pytest.mark.parametrize(
+    "driver", [SyncDriver.POSTGRESQL_PSYCOPG2, "postgresql+psycopg2"]
+)
+def test_sqlalchemy_credentials_get_connection_sync(driver):
+    @flow
+    def test_flow():
+        sqlalchemy_credentials = DatabaseCredentials(
+            driver, "user", "password", "database"
+        )
+        expected = "postgresql+psycopg2://user:***@localhost:5432/database"
+        assert sqlalchemy_credentials.engine.url.render_as_string() == expected
+        connection = sqlalchemy_credentials.get_connection()
+        assert isinstance(connection, Connection)
+        assert sqlalchemy_credentials.is_async is False
+
+    test_flow().result()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,7 +6,7 @@ from prefect import flow
 from prefect_sqlalchemy.database import sqlalchemy_execute, sqlalchemy_query
 
 
-class SQLAlchemyConnectionMock:
+class SQLAlchemyAsyncConnectionMock:
     async def __aenter__(self):
         return self
 
@@ -30,17 +30,56 @@ class SQLAlchemyConnectionMock:
         pass
 
 
+class SQLAlchemyConnectionMock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, query, params):
+        cursor_result = MagicMock()
+        cursor_result.fetchall.side_effect = lambda: [
+            (query, params),
+        ]
+        cursor_result.fetchmany.side_effect = (
+            lambda size: [
+                (query, params),
+            ]
+            * size
+        )
+        return cursor_result
+
+
 @pytest.fixture()
-def sqlalchemy_credentials():
+def sqlalchemy_credentials_async():
     sqlalchemy_credentials_mock = MagicMock()
+    sqlalchemy_credentials_mock.is_async = True
+    sqlalchemy_credentials_mock.get_connection.return_value = (
+        SQLAlchemyAsyncConnectionMock()
+    )
+    return sqlalchemy_credentials_mock
+
+
+@pytest.fixture()
+def sqlalchemy_credentials_sync():
+    sqlalchemy_credentials_mock = MagicMock()
+    sqlalchemy_credentials_mock.is_async = False
     sqlalchemy_credentials_mock.get_connection.return_value = SQLAlchemyConnectionMock()
     return sqlalchemy_credentials_mock
 
 
 @pytest.mark.parametrize("limit", [None, 3])
-def test_sqlalchemy_query(limit, sqlalchemy_credentials):
+@pytest.mark.parametrize("is_async", [True, False])
+def test_sqlalchemy_query(
+    limit, is_async, sqlalchemy_credentials_async, sqlalchemy_credentials_sync
+):
     @flow
     def test_flow():
+        if is_async:
+            sqlalchemy_credentials = sqlalchemy_credentials_async
+        else:
+            sqlalchemy_credentials = sqlalchemy_credentials_sync
         result = sqlalchemy_query(
             "query", sqlalchemy_credentials, params=("param",), limit=limit
         )
@@ -55,9 +94,16 @@ def test_sqlalchemy_query(limit, sqlalchemy_credentials):
         assert len(result) == limit
 
 
-def test_sqlalchemy_execute(sqlalchemy_credentials):
+@pytest.mark.parametrize("is_async", [True, False])
+def test_sqlalchemy_execute(
+    is_async, sqlalchemy_credentials_async, sqlalchemy_credentials_sync
+):
     @flow
     def test_flow():
+        if is_async:
+            sqlalchemy_credentials = sqlalchemy_credentials_async
+        else:
+            sqlalchemy_credentials = sqlalchemy_credentials_sync
         result = sqlalchemy_execute("query", sqlalchemy_credentials)
         return result
 


### PR DESCRIPTION
Supports sync drivers by adding an `is_async` property

Don't know why engine gets created twice though.

```
from prefect_sqlalchemy import DatabaseCredentials, SyncDriver
from prefect_sqlalchemy.database import sqlalchemy_query
from prefect import flow

@flow
def sqlalchemy_query_flow():
    sqlalchemy_credentials = DatabaseCredentials(
        driver=SyncDriver.POSTGRESQL_PSYCOPG2,
        user="andrew",
        password="",
        database="postgres",
    )
    result = sqlalchemy_query(
        "SELECT * FROM customers WHERE name = :name;",
        sqlalchemy_credentials,
        params={"name": "Marvin"},
    )
    return result

sqlalchemy_query_flow()
```


```
18:49:36.512 | INFO    | prefect.engine - Created flow run 'deft-oyster' for flow 'sqlalchemy-query-flow'
18:49:36.513 | INFO    | Flow run 'deft-oyster' - Using task runner 'ConcurrentTaskRunner'
18:49:36.519 | WARNING | Flow run 'deft-oyster' - No default storage is configured on the server. Results from this flow run will be stored in a temporary directory in its runtime environment.
18:49:36.531 | INFO    | Flow run 'deft-oyster' - Created a(n) SYNCHRONOUS engine successfully using the connection string: postgresql+psycopg2://andrew:***@localhost:5432/postgres.
18:49:36.550 | INFO    | Flow run 'deft-oyster' - Created task run 'sqlalchemy_query-702c9121-1' for task 'sqlalchemy_query'
18:49:36.552 | INFO    | Flow run 'deft-oyster' - Created a(n) SYNCHRONOUS engine successfully using the connection string: postgresql+psycopg2://andrew:***@localhost:5432/postgres.
18:49:36.630 | INFO    | Task run 'sqlalchemy_query-702c9121-1' - Finished in state Completed()
18:49:36.640 | INFO    | Flow run 'deft-oyster' - Finished in state Completed('All states completed.')
Completed(message='All states completed.', type=COMPLETED, result=Completed(message=None, type=COMPLETED, result=[('Marvin', 'Highway 42'), ('Marvin', 'Highway 42')], task_run_id=d581ce72-1a7e-46e3-9bd7-6147f8581fbe), flow_run_id=8561c3c7-ee1b-4491-9f44-d4b6e8ad157d)
```