### PR TITLE
Narrows type of `url` on `DatabaseCredentials` to fix error in block registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+Fixed registration error by changing `url` type to `AnyUrl` - [#29](https://github.com/PrefectHQ/prefect-sqlalchemy/pull/29)
+
 ### Security
 
 ## 0.1.2

--- a/prefect_sqlalchemy/credentials.py
+++ b/prefect_sqlalchemy/credentials.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
-from pydantic import SecretStr
+from pydantic import AnyUrl, SecretStr
 from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.url import URL, make_url
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -129,7 +129,7 @@ class DatabaseCredentials(Block):
     host: Optional[str] = None
     port: Optional[str] = None
     query: Optional[Dict[str, str]] = None
-    url: Optional[str] = None
+    url: Optional[AnyUrl] = None
     connect_args: Optional[Dict[str, Any]] = None
 
     def block_initialization(self):
@@ -178,7 +178,7 @@ class DatabaseCredentials(Block):
                     f"alongside any of these URL params: "
                     f"{url_params.keys()}"
                 )
-            self.rendered_url = make_url(self.url)
+            self.rendered_url = make_url(str(self.url))
 
     def get_engine(self) -> Union["Connection", "AsyncConnection"]:
         """

--- a/prefect_sqlalchemy/credentials.py
+++ b/prefect_sqlalchemy/credentials.py
@@ -129,7 +129,7 @@ class DatabaseCredentials(Block):
     host: Optional[str] = None
     port: Optional[str] = None
     query: Optional[Dict[str, str]] = None
-    url: Optional[Union[URL, str]] = None
+    url: Optional[str] = None
     connect_args: Optional[Dict[str, Any]] = None
 
     def block_initialization(self):
@@ -178,10 +178,7 @@ class DatabaseCredentials(Block):
                     f"alongside any of these URL params: "
                     f"{url_params.keys()}"
                 )
-            if not isinstance(self.url, URL):
-                self.rendered_url = make_url(self.url)  # from string
-            else:
-                self.rendered_url = self.url  # from URL
+            self.rendered_url = make_url(self.url)
 
     def get_engine(self) -> Union["Connection", "AsyncConnection"]:
         """

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -18,7 +18,7 @@ def test_sqlalchemy_credentials_post_init_url_param_conflict(url_param):
         with pytest.raises(
             ValueError, match="The `url` should not be provided alongside"
         ):
-            DatabaseCredentials(url="url", **url_params)
+            DatabaseCredentials(url="postgresql+asyncpg://user:password@localhost:5432/database", **url_params)
 
     test_flow()
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -94,20 +94,10 @@ def test_sqlalchemy_credentials_get_engine_sync(driver):
     test_flow()
 
 
-@pytest.mark.parametrize("url_type", ["string", "URL"])
-def test_sqlalchemy_credentials_get_engine_url(url_type):
+def test_sqlalchemy_credentials_get_engine_url():
     @flow
     def test_flow():
-        if url_type == "string":
-            url = "postgresql://username:password@account/database"
-        else:
-            url = URL.create(
-                "postgresql",
-                "username",
-                "password",
-                host="account",
-                database="database",
-            )
+        url = "postgresql://username:password@account/database"
         sqlalchemy_credentials = DatabaseCredentials(url=url)
         assert sqlalchemy_credentials._async_supported is False
         assert sqlalchemy_credentials.url == url

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -18,7 +18,10 @@ def test_sqlalchemy_credentials_post_init_url_param_conflict(url_param):
         with pytest.raises(
             ValueError, match="The `url` should not be provided alongside"
         ):
-            DatabaseCredentials(url="postgresql+asyncpg://user:password@localhost:5432/database", **url_params)
+            DatabaseCredentials(
+                url="postgresql+asyncpg://user:password@localhost:5432/database",
+                **url_params,
+            )
 
     test_flow()
 


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-sqlalchemy! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Fixes error in registration caused by the `URL` type from sqlalchemy. `URL` does not inherit from pydantic's `BaseModel` and we can't generate a schema for it. Narrowing the type to only `AnyUrl` fixes the issue.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
Closes #28 

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-sqlalchemy/blob/main/CHANGELOG.md)
