### PR TITLE
Prep for 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-Fixed registration error by changing `url` type to `AnyUrl` - [#29](https://github.com/PrefectHQ/prefect-sqlalchemy/pull/29)
-
 ### Security
+
+## 0.2.0
+
+Released on September 1st, 2022.
+
+### Changed
+
+- `DatabaseCredentials` now only accepts a `str` in URL format - [#29](https://github.com/PrefectHQ/prefect-sqlalchemy/pull/29)
+
+### Fixed
+
+- Fixed registration error by changing `url` type to `AnyUrl` - [#29](https://github.com/PrefectHQ/prefect-sqlalchemy/pull/29)
 
 ## 0.1.2
 


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-sqlalchemy! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
I'm proposing a release under 0.2.0 because we no longer accept a `URL` type in the `url` attribute of `DatabaseCredentials`. That change is highlighted under `Changed` in the change log entry.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-sqlalchemy/blob/main/CHANGELOG.md)
