### PR TITLE
Fix fetch flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.4
+
+Released on February 15th, 2022.
+
+### Fixed
+
+- Initializing `_unique_results` and `_exit_stack` so `fetch_*` is able to run - [#49](https://github.com/PrefectHQ/prefect-sqlalchemy/pull/49)
+
 ## 0.2.3
 
 Released on February 10th, 2022.

--- a/prefect_sqlalchemy/database.py
+++ b/prefect_sqlalchemy/database.py
@@ -301,6 +301,12 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         except ValueError:
             self._driver_is_async = False
 
+        if self._unique_results is None:
+            self._unique_results = {}
+
+        if self._exit_stack is None:
+            self._start_exit_stack()
+
     def _start_exit_stack(self):
         """
         Starts an AsyncExitStack or ExitStack depending on whether driver is async.
@@ -378,10 +384,6 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
 
         if self._engine is None:
             self._engine = engine
-        if self._exit_stack is None:
-            self._start_exit_stack()
-        if self._unique_results is None:
-            self._unique_results = {}
 
         return engine
 
@@ -938,3 +940,9 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
     def __setstate__(self, data: dict):
         """Upon loading back, restart the engine and results."""
         self.__dict__.update(data)
+
+        if self._unique_results is None:
+            self._unique_results = {}
+
+        if self._exit_stack is None:
+            self._start_exit_stack()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -269,10 +269,12 @@ class TestSqlAlchemyConnector:
             ),
         ) as connector:
             connector.reset_connections()
-            assert caplog.records[0].msg == "There were no connections to reset."
+            assert (
+                caplog.records[0].msg == "Reset opened connections and their results."
+            )
             assert connector._engine is None
-            assert connector._unique_results is None
-            assert connector._exit_stack is None
+            assert connector._unique_results == {}
+            assert isinstance(connector._exit_stack, ExitStack)
             connector.execute("SELECT 1")
             assert isinstance(connector._engine, Engine)
             assert connector._unique_results == {}

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import cloudpickle
 import pytest
-from prefect import flow
+from prefect import flow, task
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
@@ -547,3 +547,52 @@ class TestSqlAlchemyConnector:
         assert len(conn._unique_results) == 1
         conn.reset_connections()
         assert len(conn._unique_results) == 0
+
+    def test_flow_without_initialized_engine(self, tmp_path):
+        @task
+        def setup_table(block_name: str) -> None:
+            with SqlAlchemyConnector.load(block_name) as connector:
+                connector.execute(
+                    "CREATE TABLE IF NOT EXISTS customers (name varchar, address varchar);"  # noqa
+                )
+                connector.execute(
+                    "INSERT INTO customers (name, address) VALUES (:name, :address);",
+                    parameters={"name": "Marvin", "address": "Highway 42"},
+                )
+                connector.execute_many(
+                    "INSERT INTO customers (name, address) VALUES (:name, :address);",
+                    seq_of_parameters=[
+                        {"name": "Ford", "address": "Highway 42"},
+                        {"name": "Unknown", "address": "Highway 42"},
+                    ],
+                )
+
+        @task
+        def fetch_data(block_name: str) -> list:
+            all_rows = []
+            with SqlAlchemyConnector.load(block_name) as connector:
+                while True:
+                    # Repeated fetch* calls using the same operation will
+                    # skip re-executing and instead return the next set of results
+                    new_rows = connector.fetch_many("SELECT * FROM customers", size=2)
+                    if len(new_rows) == 0:
+                        break
+                    all_rows.append(new_rows)
+            return all_rows
+
+        @flow
+        def sqlalchemy_flow(block_name: str) -> list:
+            SqlAlchemyConnector(
+                connection_info=ConnectionComponents(
+                    driver=SyncDriver.SQLITE_PYSQLITE,
+                    database=str(tmp_path / "test.db"),
+                )
+            ).save(block_name)
+            setup_table(block_name)
+            all_rows = fetch_data(block_name)
+            return all_rows
+
+        assert sqlalchemy_flow("connector") == [
+            [("Marvin", "Highway 42"), ("Ford", "Highway 42")],
+            [("Unknown", "Highway 42")],
+        ]


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes https://github.com/PrefectHQ/prefect-sqlalchemy/issues/48

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
```
from prefect import flow, task
from prefect_sqlalchemy import SqlAlchemyConnector


@task
def setup_table(block_name: str) -> None:
    with SqlAlchemyConnector.load(block_name) as connector:
        connector.execute(
            "CREATE TABLE IF NOT EXISTS customers (name varchar, address varchar);"
        )
        connector.execute(
            "INSERT INTO customers (name, address) VALUES (:name, :address);",
            parameters={"name": "Marvin", "address": "Highway 42"},
        )
        connector.execute_many(
            "INSERT INTO customers (name, address) VALUES (:name, :address);",
            seq_of_parameters=[
                {"name": "Ford", "address": "Highway 42"},
                {"name": "Unknown", "address": "Highway 42"},
            ],
        )

@task
def fetch_data(block_name: str) -> list:
    all_rows = []
    with SqlAlchemyConnector.load(block_name) as connector:
        while True:
            # Repeated fetch* calls using the same operation will
            # skip re-executing and instead return the next set of results
            new_rows = connector.fetch_many("SELECT * FROM customers", size=2)
            if len(new_rows) == 0:
                break
            all_rows.append(new_rows)
    return all_rows

@flow
def sqlalchemy_flow(block_name: str) -> list:
    setup_table(block_name)
    all_rows = fetch_data(block_name)
    return all_rows


sqlalchemy_flow("connector")
```


### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

![image](https://user-images.githubusercontent.com/15331990/219121677-8b6cbcbd-43f3-4dd4-9fbf-6c3b3b511fdc.png)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-sqlalchemy/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-sqlalchemy/blob/main/CHANGELOG.md)
