### PR TITLE
Change port to int

### DIFF
--- a/prefect_sqlalchemy/credentials.py
+++ b/prefect_sqlalchemy/credentials.py
@@ -112,7 +112,7 @@ class ConnectionComponents(BaseModel):
     host: Optional[str] = Field(
         default=None, description="The host address of the database."
     )
-    port: Optional[str] = Field(
+    port: Optional[int] = Field(
         default=None, description="The port to connect to the database."
     )
     query: Optional[Dict[str, str]] = Field(
@@ -201,7 +201,7 @@ class DatabaseCredentials(Block):
     host: Optional[str] = Field(
         default=None, description="The host address of the database."
     )
-    port: Optional[str] = Field(
+    port: Optional[int] = Field(
         default=None, description="The port to connect to the database."
     )
     query: Optional[Dict[str, str]] = Field(

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -21,6 +21,8 @@ def test_sqlalchemy_credentials_post_init_url_param_conflict(url_param):
         url_params = {url_param: url_param}
         if url_param == "query":
             url_params["query"] = {"query": "query"}
+        elif url_param == "port":
+            url_params["port"] = 5432
         with pytest.raises(
             ValueError, match="The `url` should not be provided alongside"
         ):

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -161,7 +161,7 @@ def test_save_load_roundtrip():
     assert loaded_credentials.password.get_secret_value() == "test-password"
     assert loaded_credentials.database == "test-database"
     assert loaded_credentials.host == "localhost"
-    assert loaded_credentials.port == "5678"
+    assert loaded_credentials.port == 5678
     assert loaded_credentials.rendered_url == credentials.rendered_url
 
 
@@ -182,6 +182,7 @@ def test_sqlalchemy_connection_components_create_url_optional_params():
         port=1234,
         host="localhost",
     )
+    assert isinstance(connection_components.port, int)
     actual = connection_components.create_url()
     assert actual == make_url(
         "postgresql+psycopg2://myusername:mypass@localhost:1234/my.db"


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
User reports "Version 0.3.0 creates an invalid dbt profile for postgres. Port value in the target config is set as string which fails dbt cli run. Profile is correct with version 0.2.7."

Unsure if changes should be made in prefect-dbt or here... If prefect-dbt; relevant PR: https://github.com/PrefectHQ/prefect-dbt/pull/132

Closes https://github.com/PrefectHQ/prefect-dbt/issues/131

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-sqlalchemy/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-sqlalchemy/blob/main/CHANGELOG.md)
