### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_sqlalchemy/credentials.py
+++ b/prefect_sqlalchemy/credentials.py
@@ -5,7 +5,13 @@ from enum import Enum
 from typing import Any, Dict, Optional, Union
 
 from prefect.blocks.core import Block
-from pydantic import AnyUrl, BaseModel, Field, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import AnyUrl, BaseModel, Field, SecretStr
+else:
+    from pydantic import AnyUrl, BaseModel, Field, SecretStr
+
 from sqlalchemy.engine import Connection, create_engine
 from sqlalchemy.engine.url import URL, make_url
 from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine

--- a/prefect_sqlalchemy/database.py
+++ b/prefect_sqlalchemy/database.py
@@ -9,7 +9,13 @@ from prefect import task
 from prefect.blocks.abstract import CredentialsBlock, DatabaseBlock
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.hashing import hash_objects
-from pydantic import AnyUrl, Field, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import AnyUrl, Field, SecretStr
+else:
+    from pydantic import AnyUrl, Field, SecretStr
+
 from sqlalchemy.engine import Connection, Engine, create_engine
 from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.engine.url import URL, make_url

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 prefect>=2.7.0
-sqlalchemy>=1.4.31
+sqlalchemy>=1.4.31,<2


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.