### PR TITLE
Fix async example in documentation for data fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Be sure to install [prefect-sqlalchemy](#installation) and [save your credential
     @task
     async def fetch_data(block_name: str) -> list:
         all_rows = []
-        async with SqlAlchemyConnector.load(block_name) as connector:
+        async with await SqlAlchemyConnector.load(block_name) as connector:
             while True:
                 # Repeated fetch* calls using the same operation will
                 # skip re-executing and instead return the next set of results
@@ -165,7 +165,7 @@ The tasks in this library are designed to work with Prefect 2. For more informat
 
 To use the `load` method on Blocks, you must have a block document [saved through code](https://docs.prefect.io/concepts/blocks/#saving-blocks) or saved through the UI.
 
-Below is a walkthrough on saving block documents through code; simply create a short script, replacing the placeholders. 
+Below is a walkthrough on saving block documents through code; simply create a short script, replacing the placeholders.
 
 ```python
 from prefect_sqlalchemy import SqlAlchemyConnector, ConnectionComponents, SyncDriver


### PR DESCRIPTION
There is a mistake in the documentation regarding how to use a connector to run a `fetch_all()` asynchronously (an `await` is missing). I have added it to the documentation in the `README.md`.

Closes

### Example

### Screenshots

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-sqlalchemy/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
